### PR TITLE
Add CSS selector labels to screenshots

### DIFF
--- a/.cursor/rules/visual_qa.mdc
+++ b/.cursor/rules/visual_qa.mdc
@@ -90,8 +90,6 @@ llm -m openrouter/qwen/qwen2.5-vl-32b-instruct \
 
 Simon Willison's `llm` tool is available for vision model analysis.
 
-**CSS selector labels:** Add `--annotate` flag to screenshots to overlay element selectors for vision model communication.
-
 **Attach images:**
 ```bash
 llm -m openrouter/qwen/qwen2.5-vl-32b-instruct \
@@ -114,6 +112,8 @@ llm -m openrouter/qwen/qwen2.5-vl-32b-instruct \
     -a image.png \
     "Score the image" --schema "score int: Score 0-10" --xl | jq .  # Extracts last fenced code block
 ```
+
+**Add CSS selector labels:** Adding the `--annotate` flag when capturing screenshots will overlay element selectors to help the vision model communicate with you about layout and styling.
 
 Other uses include asking focused questions for visual understanding:
 - "Is the nav bar obscuring any page content?"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,8 +149,6 @@ The user will review staged changes and commit manually with GPG signing.
 
 Simon Willison's `llm` tool is available for vision model analysis.
 
-**CSS selector labels:** Add `--annotate` flag to screenshots to overlay element selectors for vision model communication.
-
 **Attach images:**
 ```bash
 llm -m openrouter/qwen/qwen2.5-vl-32b-instruct \
@@ -173,6 +171,8 @@ llm -m openrouter/qwen/qwen2.5-vl-32b-instruct \
     -a image.png \
     "Score the image" --schema "score int: Score 0-10" --xl | jq .  # Extracts last fenced code block
 ```
+
+**Add CSS selector labels:** Adding the `--annotate` flag when capturing screenshots will overlay element selectors to help the vision model communicate with you about layout and styling.
 
 Other uses include asking focused questions for visual understanding:
 - "Is the nav bar obscuring any page content?"

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "christophercarrollsmith-website",


### PR DESCRIPTION
…creenshots

Enables vision models to reference specific page elements by their CSS selectors during visual QA.