### PR TITLE
Set up Cursor Cloud dev environment (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md
+
+General tech-stack and code conventions live in `CLAUDE.md`. Standard scripts are
+defined in `package.json` (`dev`, `build`, `lint`, `test`, `test:e2e`, `preview`).
+
+## Cursor Cloud specific instructions
+
+The dev environment is refreshed automatically by the update script (`bun install`
+plus a Playwright Chromium refresh); `bun` and the Playwright browsers are already
+present from the VM snapshot, so no manual install steps are needed.
+
+Services and how to run them:
+
+- Dev server (main app): `bun run dev` serves the Astro + React site on
+  `http://localhost:4321`. This is all you need for interactive/UI work and hot reload.
+- Production preview: `bun run build` then `bun run preview` (also on port 4321).
+  `build` runs Substack/YouTube RSS sync, CV PDF generation, and Mermaid image
+  rendering before `astro build`. The sync steps hit the network but fail/skip
+  gracefully offline, so `build` still succeeds without connectivity.
+
+Non-obvious gotchas:
+
+- Tests run against the production `preview` build, not the dev server. Because
+  `playwright.config.js` uses `reuseExistingServer: !process.env.CI`, a dev server
+  already listening on port 4321 will be reused and the suite will fail. Run tests
+  with `CI=1` (e.g. `CI=1 bun run test:e2e`) or ensure port 4321 is free first so
+  Playwright starts its own `bun run preview` server.
+- `bun run test:e2e` requires a prior successful `bun run build` (the preview server
+  serves `dist/`).
+- Substack HTML→markdown conversion in `scripts/sync-substack.ts` shells out to
+  `pandoc`; it is only invoked when new Substack posts are found, so `build` works
+  without `pandoc` in the common case.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cloud Agent development environment for this Astro + React + Bun site and documents non-obvious run/test caveats for future agents.

- Installs Bun runtime, project dependencies (`bun install`), and Playwright Chromium.
- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section describing services (dev server, preview build) and gotchas.
- Update script configured to `bun install` + `bunx playwright install chromium`.

## Verification

| Task | Command | Result |
|---|---|---|
| Lint | `bun run lint` | pass (clean) |
| Build | `bun run build` | pass (39 pages) |
| Tests | `CI=1 bun run test:e2e` | pass (56 e2e + 10 a11y) |
| Run app | `bun run dev` → `http://localhost:4321` | serves home/cv/blog (200) |

Key gotcha documented: tests must run against the production `preview` build. Because `playwright.config.js` uses `reuseExistingServer: !process.env.CI`, a running dev server on port 4321 gets reused and the suite fails; run with `CI=1` or free port 4321 first.

## Hello-world walkthrough

Manually exercised core functionality: home hero, nav to Projects, filling the contact form, blog listing, and an individual blog post render.

[astro_site_hello_world_walkthrough.mp4](https://cursor.com/agents/bc-240ac497-3e93-49c7-bc94-04847ddaac7b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fastro_site_hello_world_walkthrough.mp4)

[Contact form filled with test input](https://cursor.com/agents/bc-240ac497-3e93-49c7-bc94-04847ddaac7b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcontact_form_filled.webp)
[Rendered blog post](https://cursor.com/agents/bc-240ac497-3e93-49c7-bc94-04847ddaac7b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_post_rendered.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-240ac497-3e93-49c7-bc94-04847ddaac7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-240ac497-3e93-49c7-bc94-04847ddaac7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

