### PR TITLE
Improve SEO: sitemap filter, OG/Twitter meta, redirects, landmarks

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -3,13 +3,17 @@ import react from '@astrojs/react';
 import sitemap from '@astrojs/sitemap';
 import mdx from '@astrojs/mdx';
 import { remarkMermaidImages } from './src/remark/remarkMermaidImages';
+import { getLegacyBlogRedirects, shouldIncludeInSitemap } from './src/seo/blogRoutes';
 
 // https://astro.build/config
 export default defineConfig({
   site: 'https://christophercarrollsmith.com',
+  redirects: getLegacyBlogRedirects(),
   integrations: [
     react(),
-    sitemap(),
+    sitemap({
+      filter: shouldIncludeInSitemap,
+    }),
     mdx({
       remarkPlugins: [remarkMermaidImages],
     }),

--- a/src/App.css
+++ b/src/App.css
@@ -189,6 +189,33 @@ section.white {
   min-height: 100vh;
 }
 
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.category-title-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  justify-content: center;
+  width: 100%;
+  flex: 1 0 200px;
+  margin: 0.5rem;
+  position: relative;
+  overflow: visible;
+  padding: 1rem;
+  border-radius: 15px;
+}
+
 /* Reasonable defaults for headings site-wide */
 h1 {
   font-weight: 300;

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -34,6 +34,7 @@ const About: React.FC = () => {
       )}
       <div className="hero-content">
         <div className="about-section">
+          <h2 className="visually-hidden">About</h2>
           <div className="bio bio-animated">
             {bioSentences.map((sentence, i) => (
               <span key={i} className="bio-sentence">

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -5,34 +5,47 @@ interface CardProps {
   project: Project;
 }
 
-const Card: React.FC<CardProps> = ({ project }) => (
-  <div className={`project-card ${project.iconOverlay ? 'featured' : ''}`}>
-    <div className="content-wrapper">
-      <div className="title-section">
-        <div className="title-container">
-          <h3>{project.title}</h3>
+const isExternalUrl = (url: string) => /^https?:\/\//i.test(url);
+
+const Card: React.FC<CardProps> = ({ project }) => {
+  const external = isExternalUrl(project.url);
+
+  return (
+    <div className={`project-card ${project.iconOverlay ? 'featured' : ''}`}>
+      <div className="content-wrapper">
+        <div className="title-section">
+          <div className="title-container">
+            <h3>{project.title}</h3>
+          </div>
+        </div>
+        {project.img && (
+          <div className="image-section">
+            <img src={`/images/${project.img}`} alt={project.title} />
+          </div>
+        )}
+        <div className={`body-section ${project.img ? 'with-image' : ''}`}>
+          <p>{project.description}</p>
+          <a
+            href={project.url}
+            className="button"
+            {...(external
+              ? { target: '_blank', rel: 'noopener noreferrer' }
+              : {})}
+          >
+            {project.buttonText || 'View Project'}
+          </a>
         </div>
       </div>
-      {project.img && (
-        <div className="image-section">
-          <img src={`/images/${project.img}`} alt={project.title} />
-        </div>
+      {project.iconOverlay && (
+        <img
+          src={`/images/${project.iconOverlay}`}
+          alt=""
+          className="icon-overlay"
+          aria-hidden="true"
+        />
       )}
-      <div className={`body-section ${project.img ? 'with-image' : ''}`}>
-        <p>{project.description}</p>
-        <a href={project.url} target="_blank" rel="noopener noreferrer" className="button">
-          View Project
-        </a>
-      </div>
     </div>
-    {project.iconOverlay && (
-      <img
-        src={`/images/${project.iconOverlay}`}
-        alt="Icon Overlay"
-        className="icon-overlay"
-      />
-    )}
-  </div>
-);
+  );
+};
 
 export default Card;

--- a/src/components/Events.tsx
+++ b/src/components/Events.tsx
@@ -124,7 +124,7 @@ const Events: React.FC = () => {
       <div className="hero-content">
         <div className="events-content">
           <header className="events-header">
-            <h1>Events</h1>
+            <h2>Events</h2>
             <p className="events-subhead">
               Workshops, talks, and community sessions about AI workflows and tooling.
             </p>

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -12,6 +12,10 @@
     z-index: 20;
   }
 
+  #header nav {
+    display: contents;
+  }
+
   #header a {
     text-decoration: none;
     color: black;

--- a/src/components/HeaderAstro.astro
+++ b/src/components/HeaderAstro.astro
@@ -4,15 +4,17 @@ import './Header.css';
 const currentPath = Astro.url.pathname;
 ---
 
-<div id="header">
-  <a href="/#home" data-hash-link>Home</a>
-  <a href="/#about" data-hash-link>About</a>
-  <a href="/#projects" data-hash-link>Projects</a>
-  <a href="/#writing" data-hash-link>Writing</a>
-  <a href="/#events" data-hash-link>Events</a>
-  <a href="/cv" class:list={[{ active: currentPath.startsWith('/cv') }]}>CV</a>
-  <a href="/blog" class:list={[{ active: currentPath.startsWith('/blog') }]}>Blog</a>
-</div>
+<header id="header">
+  <nav aria-label="Primary">
+    <a href="/#home" data-hash-link>Home</a>
+    <a href="/#about" data-hash-link>About</a>
+    <a href="/#projects" data-hash-link>Projects</a>
+    <a href="/#writing" data-hash-link>Writing</a>
+    <a href="/#events" data-hash-link>Events</a>
+    <a href="/cv" class:list={[{ active: currentPath.startsWith('/cv') }]}>CV</a>
+    <a href="/blog" class:list={[{ active: currentPath.startsWith('/blog') }]}>Blog</a>
+  </nav>
+</header>
 
 <script>
   // Handle hash navigation from non-home pages

--- a/src/components/Projects.css
+++ b/src/components/Projects.css
@@ -14,18 +14,3 @@
   gap: 2rem;
 }
 
-
-.category-title-container {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
-  justify-content: center;
-  width: 100%;
-  flex: 1 0 200px;
-  margin: 0.5rem;
-  position: relative;
-  overflow: visible;
-  padding: 1rem;
-  border-radius: 15px;
-}

--- a/src/components/Writing.tsx
+++ b/src/components/Writing.tsx
@@ -11,6 +11,12 @@ const Writing: React.FC = () => {
 
   const writingData = [
     {
+      title: "Blog",
+      description: "Original essays and technical writing on AI, software, and data",
+      buttonText: "Read",
+      url: "/blog"
+    },
+    {
       title: "A Knowledge Workers' Guide to the Singularity",
       description: "A Substack newsletter on staying employed in knowledge work amid major technological disruption by AI",
       buttonText: "Substack",
@@ -48,6 +54,9 @@ const Writing: React.FC = () => {
       )}
       <div className="hero-content">
         <div className="writing-grid">
+          <div className="category-title-container">
+            <h2 className="category-title">Writing</h2>
+          </div>
           {writingData.map((writing, index) => (
             <Card key={index} project={writing} />
           ))}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,4 +1,7 @@
 ---
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import sizeOf from 'image-size';
 import '../main.css';
 import '../App.css';
 
@@ -6,6 +9,7 @@ interface Props {
   title?: string;
   description?: string;
   image?: string;
+  imageAlt?: string;
   type?: string;
   canonicalURL?: string;
 }
@@ -14,13 +18,27 @@ const {
   title = "Christopher Carroll Smith",
   description = "Website of Christopher Carroll Smith, software architect, data storyteller, and president of Promptly Technologies, LLC.",
   image = "/images/Chris_landscape.jpg",
+  imageAlt = title,
   type = "website",
   canonicalURL
 } = Astro.props;
 
 const siteURL = 'https://christophercarrollsmith.com';
+const siteName = 'Christopher Carroll Smith';
 const canonical = canonicalURL || new URL(Astro.url.pathname, siteURL).href;
 const absoluteImage = image.startsWith('http') ? image : new URL(image, siteURL).href;
+
+let imageWidth: number | undefined;
+let imageHeight: number | undefined;
+if (!image.startsWith('http')) {
+  try {
+    const dimensions = sizeOf(readFileSync(join(process.cwd(), 'public', image.replace(/^\/+/, ''))));
+    imageWidth = dimensions.width;
+    imageHeight = dimensions.height;
+  } catch {
+    // Dimensions are optional enrichment for Open Graph consumers.
+  }
+}
 ---
 
 <!DOCTYPE html>
@@ -39,17 +57,24 @@ const absoluteImage = image.startsWith('http') ? image : new URL(image, siteURL)
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content={type} />
+    <meta property="og:site_name" content={siteName} />
+    <meta property="og:locale" content="en_US" />
     <meta property="og:url" content={canonical} />
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
     <meta property="og:image" content={absoluteImage} />
+    <meta property="og:image:alt" content={imageAlt} />
+    {imageWidth && <meta property="og:image:width" content={String(imageWidth)} />}
+    {imageHeight && <meta property="og:image:height" content={String(imageHeight)} />}
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:creator" content="Christopher Carroll Smith" />
+    <meta name="twitter:site" content="@christophcsmith" />
+    <meta name="twitter:creator" content="@christophcsmith" />
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={description} />
     {image && <meta name="twitter:image" content={absoluteImage} />}
+    {image && <meta name="twitter:image:alt" content={imageAlt} />}
 
     <!-- Additional head content -->
     <slot name="head" />

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -11,7 +11,13 @@ import type { CollectionEntry } from 'astro:content';
 
 export async function getStaticPaths() {
   const posts = await getCollection('blog');
-  return posts.map((post) => ({ params: { slug: post.slug } }));
+  const paths: Array<{ params: { slug: string } }> = [];
+
+  for (const post of posts) {
+    paths.push({ params: { slug: post.slug } });
+  }
+
+  return paths;
 }
 
 const slugParam = Astro.params.slug;

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -11,47 +11,36 @@ import type { CollectionEntry } from 'astro:content';
 
 export async function getStaticPaths() {
   const posts = await getCollection('blog');
-  const paths: Array<{ params: { slug: string } }> = [];
-
-  for (const post of posts) {
-    paths.push({ params: { slug: post.slug } });
-    if (post.data.legacyId !== undefined) {
-      paths.push({ params: { slug: String(post.data.legacyId) } });
-    }
-  }
-
-  return paths;
+  return posts.map((post) => ({ params: { slug: post.slug } }));
 }
 
 const slugParam = Astro.params.slug;
 const slug = Array.isArray(slugParam) ? slugParam.join('/') : slugParam ?? '';
 
 const posts = (await getCollection('blog')) as CollectionEntry<'blog'>[];
-const legacyTarget = posts.find(
-  (p: CollectionEntry<'blog'>) => p.data.legacyId !== undefined && String(p.data.legacyId) === slug,
-);
-const post = legacyTarget ?? posts.find((p: CollectionEntry<'blog'>) => p.slug === slug);
+const post = posts.find((p: CollectionEntry<'blog'>) => p.slug === slug);
 
 if (!post) {
   throw new Error(`Blog post not found for slug: ${slug}`);
 }
 
-const isLegacyRedirect = legacyTarget !== undefined && legacyTarget.slug !== slug;
-const isSyndicated = !isLegacyRedirect && post.data.sourceUrl !== undefined;
-const targetPath = `/blog/${post.slug}`;
-const canonicalURL = new URL(targetPath, 'https://christophercarrollsmith.com').href;
+const isSyndicated = post.data.sourceUrl !== undefined;
+const canonicalURL = new URL(`/blog/${post.slug}`, 'https://christophercarrollsmith.com').href;
 
 const pageTitle = `${post.data.title.slice(0, 60)} | Christopher Carroll Smith`;
 const pageDescription = post.data.excerpt.slice(0, 155) + '...';
 const pageImage = post.data.image || '/images/Chris_landscape.jpg';
+const absoluteImage = pageImage.startsWith('http')
+  ? pageImage
+  : new URL(pageImage, 'https://christophercarrollsmith.com').href;
 
-// Schema.org structured data for the article (only on canonical pages)
+// Schema.org structured data for the article
 const structuredData = {
   '@context': 'https://schema.org',
   '@type': 'BlogPosting',
   headline: post.data.title,
   description: post.data.excerpt,
-  image: pageImage,
+  image: absoluteImage,
   datePublished: post.data.date,
   dateModified: post.data.date,
   author: {
@@ -92,66 +81,43 @@ function sourceLabel(url: string): string {
   title={pageTitle}
   description={pageDescription}
   image={pageImage}
+  imageAlt={post.data.title}
   type="article"
   canonicalURL={canonicalURL}
 >
   <Fragment slot="head">
-    {isLegacyRedirect && (
-      <>
-        <meta http-equiv="refresh" content={`0; url=${targetPath}`} />
-        <meta name="robots" content="noindex,follow" />
-      </>
-    )}
-
-    {!isLegacyRedirect && (
-      <>
-        {isSyndicated && <meta name="robots" content="noindex,follow" />}
-        <meta property="article:published_time" content={post.data.date} />
-        <meta property="article:modified_time" content={post.data.date} />
-        <meta property="article:author" content="Christopher Carroll Smith" />
-        <script is:inline type="application/ld+json" set:html={JSON.stringify(structuredData)} />
-      </>
-    )}
+    {isSyndicated && <meta name="robots" content="noindex,follow" />}
+    <meta property="article:published_time" content={post.data.date} />
+    <meta property="article:modified_time" content={post.data.date} />
+    <meta property="article:author" content="Christopher Carroll Smith" />
+    <script is:inline type="application/ld+json" set:html={JSON.stringify(structuredData)} />
   </Fragment>
 
   <div class="App">
     <HeaderAstro />
-    <div class="blog-container">
+    <main class="blog-container">
       <article class="blog-post">
-        {isLegacyRedirect ? (
-          <>
-            <h1>Redirecting…</h1>
-            <p>
-              This post has moved to <a href={targetPath}>{targetPath}</a>.
-            </p>
-          </>
-        ) : (
-          <>
-            <h1>{post.data.title}</h1>
-            <div class="post-meta">
-              <time datetime={post.data.date}>{formatBlogDate(post.data.date)}</time>
-              <span class="author-byline">By Christopher Carroll Smith</span>
-              {post.data.sourceUrl && (
-                <span class="source-attribution">
-                  · Originally published on <a href={post.data.sourceUrl}>{sourceLabel(post.data.sourceUrl)}</a>
-                </span>
-              )}
-            </div>
-            <p class="post-abstract">{post.data.excerpt}</p>
-            <Content />
-          </>
-        )}
+        <h1>{post.data.title}</h1>
+        <div class="post-meta">
+          <time datetime={post.data.date}>{formatBlogDate(post.data.date)}</time>
+          <span class="author-byline">By Christopher Carroll Smith</span>
+          {post.data.sourceUrl && (
+            <span class="source-attribution">
+              · Originally published on <a href={post.data.sourceUrl}>{sourceLabel(post.data.sourceUrl)}</a>
+            </span>
+          )}
+        </div>
+        <p class="post-abstract">{post.data.excerpt}</p>
+        <Content />
       </article>
-    </div>
+    </main>
     <Footer client:load />
   </div>
 
-  {!isLegacyRedirect && (
-    <script>
-      import Prism from 'prismjs';
-      import 'prismjs/components/prism-python';
+  <script>
+    import Prism from 'prismjs';
+    import 'prismjs/components/prism-python';
 
-      Prism.highlightAll();
-    </script>
-  )}
+    Prism.highlightAll();
+  </script>
 </BaseLayout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -64,7 +64,7 @@ const postsWithAspectRatio = sortedBlogData.map(post => {
 >
   <div class="App">
     <HeaderAstro />
-    <div class="blog-container">
+    <main class="blog-container">
       <h1>Blog</h1>
       {postsWithAspectRatio.map((item, index) => {
         const { post } = item;
@@ -132,7 +132,7 @@ const postsWithAspectRatio = sortedBlogData.map(post => {
           </article>
         );
       })}
-    </div>
+    </main>
     <Footer client:load />
   </div>
 </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -18,12 +18,14 @@ import '../App.css';
 >
   <div class="App">
     <HeaderAstro />
-    <HomeClient client:load />
-    <About client:load />
-    <Projects client:load />
-    <ProjectFeature client:load />
-    <Writing client:only="react" />
-    <Events client:only="react" />
+    <main>
+      <HomeClient client:load />
+      <About client:load />
+      <Projects client:load />
+      <ProjectFeature client:load />
+      <Writing client:only="react" />
+      <Events client:only="react" />
+    </main>
     <Footer client:load />
   </div>
 </BaseLayout>

--- a/src/seo/blogRoutes.ts
+++ b/src/seo/blogRoutes.ts
@@ -1,0 +1,77 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const SITE_URL = 'https://christophercarrollsmith.com';
+const BLOG_DIR = join(process.cwd(), 'src/content/blog');
+
+export type BlogRouteMeta = {
+  slug: string;
+  legacyId?: string;
+  isSyndicated: boolean;
+};
+
+function parseFrontmatter(raw: string): Record<string, string> {
+  const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return {};
+
+  const fields: Record<string, string> = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const separator = line.indexOf(':');
+    if (separator === -1) continue;
+    const key = line.slice(0, separator).trim();
+    const value = line.slice(separator + 1).trim().replace(/^['"]|['"]$/g, '');
+    if (key) fields[key] = value;
+  }
+  return fields;
+}
+
+export function getBlogRouteMeta(): BlogRouteMeta[] {
+  return readdirSync(BLOG_DIR)
+    .filter((name) => name.endsWith('.mdx') || name.endsWith('.md'))
+    .map((name) => {
+      const slug = name.replace(/\.mdx?$/, '');
+      const fields = parseFrontmatter(readFileSync(join(BLOG_DIR, name), 'utf8'));
+      return {
+        slug,
+        legacyId: fields.legacyId,
+        isSyndicated: Boolean(fields.sourceUrl),
+      };
+    });
+}
+
+export function getLegacyBlogRedirects(): Record<string, string> {
+  const redirects: Record<string, string> = {};
+  for (const post of getBlogRouteMeta()) {
+    if (post.legacyId) {
+      redirects[`/blog/${post.legacyId}`] = `/blog/${post.slug}`;
+    }
+  }
+  return redirects;
+}
+
+function normalizeSitemapPath(page: string): string {
+  const { pathname } = new URL(page);
+  return pathname.replace(/\/+$/, '') || '/';
+}
+
+/** Exclude syndicated (noindex) posts and legacy numeric blog paths from the sitemap. */
+export function shouldIncludeInSitemap(page: string): boolean {
+  const path = normalizeSitemapPath(page);
+  const posts = getBlogRouteMeta();
+
+  if (/^\/blog\/\d+$/.test(path)) {
+    return false;
+  }
+
+  const blogMatch = path.match(/^\/blog\/([^/]+)$/);
+  if (blogMatch) {
+    const post = posts.find((entry) => entry.slug === blogMatch[1]);
+    if (post?.isSyndicated) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export { SITE_URL };

--- a/src/seo/blogRoutes.ts
+++ b/src/seo/blogRoutes.ts
@@ -65,7 +65,8 @@ export function shouldIncludeInSitemap(page: string): boolean {
 
   const blogMatch = path.match(/^\/blog\/([^/]+)$/);
   if (blogMatch) {
-    const post = posts.find((entry) => entry.slug === blogMatch[1]);
+    const slug = blogMatch[1].toLowerCase();
+    const post = posts.find((entry) => entry.slug.toLowerCase() === slug);
     if (post?.isSyndicated) {
       return false;
     }

--- a/tests/blog-legacy-redirect.spec.ts
+++ b/tests/blog-legacy-redirect.spec.ts
@@ -9,12 +9,11 @@ test.describe('Blog legacy numeric ID behavior', () => {
     const html = await response.text();
 
     expect(html).toContain('rel="canonical"');
-    expect(html).toContain('https://christophercarrollsmith.com/blog/xor-encryption');
-    expect(html).toContain('http-equiv="refresh"');
-    expect(html).toContain('0; url=/blog/xor-encryption');
-    expect(html).toContain('name="robots"');
-    expect(html).toContain('noindex,follow');
-    expect(html).toContain('Redirecting');
+    expect(html).toContain('/blog/xor-encryption');
+    expect(html).toMatch(/http-equiv=["']refresh["']/i);
+    expect(html).toContain('/blog/xor-encryption');
+    expect(html).toMatch(/noindex/i);
+    expect(html).toMatch(/Redirecting/i);
 
     // Assert user-visible behavior: visiting the legacy URL lands on the canonical slug.
     await page.goto('/blog/1', { waitUntil: 'domcontentloaded' });
@@ -28,4 +27,3 @@ test.describe('Blog legacy numeric ID behavior', () => {
     await expect(page.locator('head meta[name="robots"][content="noindex,follow"]')).toHaveCount(0);
   });
 });
-

--- a/tests/nav-links.spec.ts
+++ b/tests/nav-links.spec.ts
@@ -72,8 +72,8 @@ test.describe('Navigation Links', () => {
       targetHash: '#events',
       verifyContent: async (page) => {
         await expect(page.locator('#events')).toBeVisible();
-        // Events section has h1 with "Events" and the visible list
-        await expect(page.locator('#events h1')).toContainText(/events/i);
+        // Events section has h2 with "Events" and the visible list
+        await expect(page.locator('#events h2')).toContainText(/events/i);
         await expect(page.locator('#events .events-list li').first()).toBeVisible();
       }
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the high-priority SEO fixes from the site audit (items 1–3 and 5–6):

1. **Sitemap hygiene** — Exclude syndicated (`sourceUrl`) posts and legacy numeric `/blog/{id}` paths via `@astrojs/sitemap` `filter` (case-insensitive slug match so YouTube paths are excluded too).
2. **Internal linking** — Add a Blog card and Writing section heading on the home Writing section so `/blog` is reachable beyond the nav.
3. **Social/meta completeness** — Add `og:site_name`, `og:locale`, `og:image:alt` / width / height, `twitter:site` / `twitter:creator` (`@christophcsmith`), and absolute `BlogPosting` image URLs.
5. **Legacy redirects** — Move numeric legacy IDs to Astro `redirects` (static meta-refresh + canonical + `noindex`; best available on GitHub Pages) instead of rendering full blog pages.
6. **Heading/landmarks** — Single home `h1`, Events as `h2`, About/Writing headings, `<header>`/`<nav>`/`<main>` landmarks on home and blog.

## Visual QA

Intentional diffs on Writing (new Blog card, heading, CTA labels) and minor Events heading weight change. Projects/home/about unchanged.

[Writing baseline](https://cursor.com/agents/bc-85b80c9b-f502-4c11-aebf-e68c0c724001/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fseo-visual-qa%2Fbaseline-xl-writing.png)
[Writing candidate](https://cursor.com/agents/bc-85b80c9b-f502-4c11-aebf-e68c0c724001/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fseo-visual-qa%2Fcandidate-xl-writing.png)
[Events candidate](https://cursor.com/agents/bc-85b80c9b-f502-4c11-aebf-e68c0c724001/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fseo-visual-qa%2Fcandidate-xl-events.png)

## Notes

- GitHub Pages cannot emit HTTP 301 for static files; Astro static redirects still use meta refresh, but are cleaner and no longer generate full post HTML for legacy IDs. The Astro dev server may serve these as 301 locally.
- Card CTAs now respect `buttonText` and open internal links in the same tab.

## Test plan

- [x] `bunx astro check && bunx astro build` — sitemap lists only 6 original blog posts (+ home/blog/cv)
- [x] `bun run lint`
- [x] `CI=1 bun run test:e2e` (56 + 10 a11y passed)
- [x] Visual QA on Writing / Events / Projects
- [x] Spot-check page source for Twitter/OG tags and blog `<main>`

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-85b80c9b-f502-4c11-aebf-e68c0c724001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85b80c9b-f502-4c11-aebf-e68c0c724001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

